### PR TITLE
Use config file in dockerfile.ocp

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -7,20 +7,9 @@ RUN yum update -y && \
 RUN mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"
 
-RUN crudini --set /etc/ironic-inspector/inspector.conf DEFAULT auth_strategy noauth && \ 
-    crudini --set /etc/ironic-inspector/inspector.conf ironic auth_type none && \
-    crudini --set /etc/ironic-inspector/inspector.conf service_catalog auth_type none && \
-    crudini --set /etc/ironic-inspector/inspector.conf DEFAULT debug true && \
-    crudini --set /etc/ironic-inspector/inspector.conf database connection sqlite:///var/lib/ironic-inspector/ironic-inspector.db && \
-    crudini --set /etc/ironic-inspector/inspector.conf DEFAULT transport_url fake:// && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing store_data database && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing ramdisk_logs_dir /shared/log/ironic-inspector/ramdisk && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing always_store_ramdisk_logs true && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing power_off false && \
-    crudini --set /etc/ironic-inspector/inspector.conf pxe_filter driver noop && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing node_not_found_hook enroll && \
-    crudini --set /etc/ironic-inspector/inspector.conf discovery enroll_node_driver ipmi && \
-    crudini --set /etc/ironic-inspector/inspector.conf processing processing_hooks "\$default_processing_hooks,extra_hardware,lldp_basic"
+COPY ./inspector.conf /tmp/inspector.conf
+RUN crudini --merge /etc/ironic-inspector/inspector.conf < /tmp/inspector.conf && \
+    rm /tmp/inspector.conf
 
 RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf upgrade 
 


### PR DESCRIPTION
Remove extended use of crudini in favor of config file
