### PR TITLE
Change store_data to "none" instead of "database".

### DIFF
--- a/inspector.conf
+++ b/inspector.conf
@@ -19,7 +19,7 @@ node_not_found_hook = enroll
 power_off = false
 processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic
 ramdisk_logs_dir = /shared/log/ironic-inspector/ramdisk
-store_data = database
+store_data = none
 
 [pxe_filter]
 driver = noop


### PR DESCRIPTION
The "database" option is not valid in the current version of Ironic in
this image.

2019-08-14 21:12:07.605 1 CRITICAL ironic_inspector [-] Unhandled error: ConfigFileValueError: Value for option store_data is not valid: Valid values are [none, swift], but found 'database'
2019-08-14 21:12:07.605 1 ERROR ironic_inspector Traceback (most recent call last):
2019-08-14 21:12:07.605 1 ERROR ironic_inspector   File "/usr/bin/ironic-inspector", line 10, in <module>
2019-08-14 21:12:07.605 1 ERROR ironic_inspector     sys.exit(main())
2019-08-14 21:12:07.605 1 ERROR ironic_inspector   File "/usr/lib/python2.7/site-packages/ironic_inspector/cmd/all.py", line 23, in main
2019-08-14 21:12:07.605 1 ERROR ironic_inspector     service_utils.prepare_service(args)
2019-08-14 21:12:07.605 1 ERROR ironic_inspector   File "/usr/lib/python2.7/site-packages/ironic_inspector/common/service_utils.py", line 30, in prepare_service
2019-08-14 21:12:07.605 1 ERROR ironic_inspector     CONF.log_opt_values(LOG, log.DEBUG)
2019-08-14 21:12:07.605 1 ERROR ironic_inspector   File "/usr/lib/python2.7/site-packages/oslo_config/cfg.py", line 3031, in log_opt_values
2019-08-14 21:12:07.605 1 ERROR ironic_inspector     _sanitize(opt, getattr(group_attr, opt_name)))
2019-08-14 21:12:07.605 1 ERROR ironic_inspector   File "/usr/lib/python2.7/site-packages/oslo_config/cfg.py", line 3551, in __getattr__
2019-08-14 21:12:07.605 1 ERROR ironic_inspector     return self._conf._get(name, self._group)
2019-08-14 21:12:07.605 1 ERROR ironic_inspector   File "/usr/lib/python2.7/site-packages/oslo_config/cfg.py", line 3073, in _get
2019-08-14 21:12:07.605 1 ERROR ironic_inspector     value, loc = self._do_get(name, group, namespace)
2019-08-14 21:12:07.605 1 ERROR ironic_inspector   File "/usr/lib/python2.7/site-packages/oslo_config/cfg.py", line 3123, in _do_get
2019-08-14 21:12:07.605 1 ERROR ironic_inspector     % (opt.name, str(ve)))
2019-08-14 21:12:07.605 1 ERROR ironic_inspector ConfigFileValueError: Value for option store_data is not valid: Valid values are [none, swift], but found 'database'
2019-08-14 21:12:07.605 1 ERROR ironic_inspector