### PR TITLE
Revert "Change store_data to "none" instead of "database"."

### DIFF
--- a/inspector.conf
+++ b/inspector.conf
@@ -19,7 +19,7 @@ node_not_found_hook = enroll
 power_off = false
 processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic
 ramdisk_logs_dir = /shared/log/ironic-inspector/ramdisk
-store_data = none
+store_data = database
 
 [pxe_filter]
 driver = noop


### PR DESCRIPTION
Recent testing indicates whatever issue we had with the previous image builds
may be resolved - see notes on https://github.com/openshift/ironic-inspector-image/pull/13

This reverts commit 483195f23ccffe6be0eaec79e29055352237f11d.