### PR TITLE
Bug 1806028: IPv6 support for inspector

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -15,6 +15,7 @@ RUN ironic-inspector-dbsync --config-file /etc/ironic-inspector/inspector.conf u
 
 COPY ./runironic-inspector.sh /bin/runironic-inspector
 COPY ./runhealthcheck.sh /bin/runhealthcheck
+COPY ./ironic-common.sh /bin/ironic-common.sh
 
 HEALTHCHECK CMD /bin/runhealthcheck
 RUN chmod +x /bin/runironic-inspector

--- a/inspector.conf
+++ b/inspector.conf
@@ -3,6 +3,7 @@ auth_strategy = noauth
 debug = true
 transport_url = fake://
 use_stderr = true
+listen_address = ::
 
 [database]
 connection = sqlite:///var/lib/ironic-inspector/ironic-inspector.db

--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -1,20 +1,20 @@
-PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
+export PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
 
 # Wait for the interface or IP to be up, sets $IRONIC_IP
 function wait_for_interface_or_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
   if [ ! -z "${PROVISIONING_IP}" ];
   then
-    IRONIC_IP=""
+    export IRONIC_IP=""
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
-      IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
+      export IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
   else
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-      IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
+      export IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
   fi
@@ -23,10 +23,10 @@ function wait_for_interface_or_ip() {
   # host needs surrounding with brackets
   if [[ "$IRONIC_IP" =~ .*:.* ]]
   then
-    IPV=6
-    IRONIC_URL_HOST="[$IRONIC_IP]"
+    export IPV=6
+    export IRONIC_URL_HOST="[$IRONIC_IP]"
   else
-    IPV=4
-    IRONIC_URL_HOST=$IRONIC_IP
+    export IPV=4
+    export IRONIC_URL_HOST=$IRONIC_IP
   fi
 }

--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -1,0 +1,29 @@
+PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
+
+# Wait for the interface or IP to be up, sets $IRONIC_IP
+function wait_for_interface_or_ip() {
+  # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
+  if [ ! -z "${PROVISIONING_IP}" ];
+  then
+    until [ ! -z "${IRONIC_IP}" ]; do
+      echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
+      IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
+      sleep 1
+    done
+  else
+    until [ ! -z "${IRONIC_IP}" ]; do
+      echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
+      IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
+      sleep 1
+    done
+
+    # If the IP contains a colon, then it's an IPv6 address, and the HTTP
+    # host needs surrounding with brackets
+    if [[ "$IRONIC_IP" =~ .*:.* ]]
+    then
+      IRONIC_URL_HOST="[$IRONIC_IP]"
+    else
+      IRONIC_URL_HOST=$IRONIC_IP
+    fi
+  fi
+}

--- a/ironic-common.sh
+++ b/ironic-common.sh
@@ -5,6 +5,7 @@ function wait_for_interface_or_ip() {
   # If $PROVISIONING_IP is specified, then we wait for that to become available on an interface, otherwise we look at $PROVISIONING_INTERFACE for an IP
   if [ ! -z "${PROVISIONING_IP}" ];
   then
+    IRONIC_IP=""
     until [ ! -z "${IRONIC_IP}" ]; do
       echo "Waiting for ${PROVISIONING_IP} to be configured on an interface"
       IRONIC_IP=$(ip -br addr show | grep "${PROVISIONING_IP}" | grep -Po "[^\s]+/[0-9]+" | sed -e 's%/.*%%' | head -n 1)
@@ -16,14 +17,16 @@ function wait_for_interface_or_ip() {
       IRONIC_IP=$(ip -br addr show dev $PROVISIONING_INTERFACE | grep -Po "[^\s]+/[0-9]+" | grep -e "^fd" -e "\." | sed -e 's%/.*%%' | head -n 1)
       sleep 1
     done
+  fi
 
-    # If the IP contains a colon, then it's an IPv6 address, and the HTTP
-    # host needs surrounding with brackets
-    if [[ "$IRONIC_IP" =~ .*:.* ]]
-    then
-      IRONIC_URL_HOST="[$IRONIC_IP]"
-    else
-      IRONIC_URL_HOST=$IRONIC_IP
-    fi
+  # If the IP contains a colon, then it's an IPv6 address, and the HTTP
+  # host needs surrounding with brackets
+  if [[ "$IRONIC_IP" =~ .*:.* ]]
+  then
+    IPV=6
+    IRONIC_URL_HOST="[$IRONIC_IP]"
+  else
+    IPV=4
+    IRONIC_URL_HOST=$IRONIC_IP
   fi
 }

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/bash
 
-PROVISIONING_INTERFACE=${PROVISIONING_INTERFACE:-"provisioning"}
-
 CONFIG=/etc/ironic-inspector/inspector.conf
-PROVISIONING_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
 
-until [ ! -z "${PROVISIONING_IP}" ]; do
-  echo "Waiting for ${PROVISIONING_INTERFACE} interface to be configured"
-  sleep 1
-  PROVISIONING_IP=$(ip -4 address show dev "$PROVISIONING_INTERFACE" | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
-done
+. /bin/ironic-common.sh
+
+wait_for_interface_or_ip
 
 # Allow access to Ironic inspector API
 if ! iptables -C INPUT -i "$PROVISIONING_INTERFACE" -p tcp -m tcp --dport 5050 -j ACCEPT > /dev/null 2>&1; then
@@ -31,11 +26,10 @@ mkdir -p /shared/log/ironic-inspector
 
 cp $CONFIG $CONFIG.orig
 
-crudini --set $CONFIG ironic endpoint_override http://$PROVISIONING_IP:6385
-crudini --set $CONFIG service_catalog endpoint_override http://$PROVISIONING_IP:5050
+crudini --set $CONFIG ironic endpoint_override http://$IRONIC_URL_HOST:6385
+crudini --set $CONFIG service_catalog endpoint_override http://$IRONIC_URL_HOST:5050
 crudini --set $CONFIG mdns interfaces $PROVISIONING_IP
 
 exec /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf \
 	--config-file /etc/ironic-inspector/inspector.conf \
 	--log-file /shared/log/ironic-inspector/ironic-inspector.log
-


### PR DESCRIPTION
This commit makes the neccessary changes for Inspector to work on IPv6,
including handling brakcets around URL's, and using the PROVISIONING_IP
variable to wait for a known IP on an interface, which may be an IPv6
address.

Cherry-picks of:
 - metal3-io#47
 - metal3-io#42
 - metal3-io#43

4.5 BZ 1806028
4.4 BZ 1806029
4.3 BZ 1806032