### PR TITLE
Do not upgrade systemd package

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,6 +1,6 @@
 FROM ubi8
 
-RUN dnf update -y && \
+RUN dnf upgrade -y  --exclude=systemd && \
     dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite && \
     mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \


### PR DESCRIPTION
The systemd package has been marked as protected and it's causing
issues when we upgrade the image.
Running dnf with the --exclude option should prevent this to
block the image build process.
Also using the correct upgrade command.