### PR TITLE
Configure inspector to keep all ports found

### DIFF
--- a/inspector.conf
+++ b/inspector.conf
@@ -15,7 +15,9 @@ enroll_node_driver = ipmi
 auth_type = none
 
 [processing]
+add_ports = all
 always_store_ramdisk_logs = true
+keep_ports = present
 node_not_found_hook = enroll
 power_off = false
 processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic


### PR DESCRIPTION
There's a note in the inspector documentation[1] that these two settings
are needed to keep all ports when doing introspection.

Without these settings, virtual media-based installs are failing as it's
skipping my interfaces:

```
2020-07-01 17:57:33.321 1 DEBUG ironic_inspector.plugins.standard [-]
[node: MAC None] Skipping interface enp1s0 as it was not PXE booting
_validate_interfaces
/usr/lib/python3.6/site-packages/ironic_inspector/plugins/standard.py:222
```

Ironic can't make the match to the existing nodes without saving all
port data.

Cherry-pick of upstream https://github.com/metal3-io/ironic-inspector-image/pull/60

[1] https://docs.openstack.org/ironic/latest/admin/inspection.html