### PR TITLE
 Backport - Add http_basic auth support

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,7 @@
 FROM ubi8
 
 RUN dnf update -y && \
-    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite && \
+    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite httpd-tools && \
     mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
     dnf remove -y sqlite && \

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/bash
 
 CONFIG=/etc/ironic-inspector/inspector.conf
+USE_HTTP_BASIC=${USE_HTTP_BASIC:-false}
+INSPECTOR_HTTP_BASIC_USERNAME=${INSPECTOR_HTTP_BASIC_USERNAME:-"change_me"}
+INSPECTOR_HTTP_BASIC_PASSWORD=${INSPECTOR_HTTP_BASIC_PASSWORD:-"change_me"}
+IRONIC_HTTP_BASIC_USERNAME=${IRONIC_HTTP_BASIC_USERNAME:-"change_me"}
+IRONIC_HTTP_BASIC_PASSWORD=${IRONIC_HTTP_BASIC_PASSWORD:-"change_me"}
 
 . /bin/ironic-common.sh
 
@@ -10,6 +15,16 @@ cp $CONFIG $CONFIG.orig
 
 crudini --set $CONFIG ironic endpoint_override http://$IRONIC_URL_HOST:6385
 crudini --set $CONFIG service_catalog endpoint_override http://$IRONIC_URL_HOST:5050
+
+if [ "$USE_HTTP_BASIC" = "true" ]; then
+        crudini --set $CONFIG DEFAULT auth_strategy http_basic
+        crudini --set $CONFIG DEFAULT http_basic_auth_user_file /shared/htpasswd-ironic-inspector
+        crudini --set $CONFIG ironic auth_type http_basic
+        crudini --set $CONFIG ironic username $IRONIC_HTTP_BASIC_USERNAME
+        crudini --set $CONFIG ironic password $IRONIC_HTTP_BASIC_PASSWORD
+
+        htpasswd -nbB $INSPECTOR_HTTP_BASIC_USERNAME $INSPECTOR_HTTP_BASIC_PASSWORD > /shared/htpasswd-ironic-inspector
+fi
 
 exec /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf \
 	--config-file /etc/ironic-inspector/inspector.conf


### PR DESCRIPTION
This commit adds the support to run ironic-inspector using `http_basic`.
To enable that is necessary to set USE_HTTP_BASIC to true, and also
specify values for the following enviroment variables:
-INSPECTOR_HTTP_BASIC_USERNAME
-INSPECTOR_HTTP_BASIC_PASSWORD
-IRONIC_HTTP_BASIC_USERNAME
-IRONIC_HTTP_BASIC_PASSWORD

Conflicts:
	Dockerfile.ocp

(cherry picked from commit 4640551)