### PR TITLE
Simplify HTTP basic auth configuration

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,7 @@
 FROM ubi8
 
 RUN dnf update -y && \
-    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite httpd-tools && \
+    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite && \
     mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
     dnf remove -y sqlite && \


### PR DESCRIPTION
* Expect the server credentials to be passed in the form of an `HTTP_BASIC_HTPASSWD` environment variable containing both the username and the *hash* of the password, in the htpasswd format. This is more secure, as it allows the container not to hold a copy of the password when it doesn't need it purely for authenticating connections.

* Expect client credentials to be passed in the form of a file named `/auth/ironic/auth-config`, formatted as an ini config file setting the appropriate options (for basic auth, this is `auth_strategy=http_basic`, and the `username` and `password` options; however this mechanism should work unchanged for other auth strategies). This is more secure because in k8s the password is never passed as an environment variable nor written to disk, but remains in a tmpfs filesystem.

This is consistent with the ironic-image configuration proposed in openshift/ironic-image#96