### PR TITLE
Bug 1898517: Disable node discovery by default

### DIFF
--- a/inspector.conf
+++ b/inspector.conf
@@ -8,9 +8,6 @@ listen_address = ::
 [database]
 connection = sqlite:///var/lib/ironic-inspector/ironic-inspector.db
 
-[discovery]
-enroll_node_driver = ipmi
-
 [ironic]
 auth_type = none
 
@@ -18,7 +15,6 @@ auth_type = none
 add_ports = all
 always_store_ramdisk_logs = true
 keep_ports = present
-node_not_found_hook = enroll
 power_off = false
 processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic
 ramdisk_logs_dir = /shared/log/ironic-inspector/ramdisk

--- a/runironic-inspector.sh
+++ b/runironic-inspector.sh
@@ -2,6 +2,8 @@
 
 CONFIG=/etc/ironic-inspector/inspector.conf
 
+export IRONIC_INSPECTOR_ENABLE_DISCOVERY=${IRONIC_INSPECTOR_ENABLE_DISCOVERY:-false}
+
 . /bin/ironic-common.sh
 
 wait_for_interface_or_ip
@@ -18,6 +20,11 @@ if [ -n "${HTTP_BASIC_HTPASSWD}" ]; then
     printf "%s\n" "${HTTP_BASIC_HTPASSWD}" >"${HTPASSWD_FILE}"
     crudini --set $CONFIG DEFAULT auth_strategy http_basic
     crudini --set $CONFIG DEFAULT http_basic_auth_user_file "${HTPASSWD_FILE}"
+fi
+
+if [[ "$IRONIC_INSPECTOR_ENABLE_DISCOVERY" == "true" ]]; then
+    crudini --set $CONFIG processing node_not_found_hook enroll
+    crudini --set $CONFIG discovery enroll_node_driver ipmi
 fi
 
 # Configure auth for ironic client


### PR DESCRIPTION
Discovery of new nodes requires explicit support from BMO, which
does not seem to exist, nor is on the roadmap. Having discovery
enabled may cause hard to debug situations when an accidentally
booted IPA results in a new node added.

An option is left to enable discovery for testing purposes or
for future implementation on the BMO side.