### PR TITLE
Move image preparation logic to a script

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -3,14 +3,10 @@ FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
 ARG PKGS_LIST=main-packages-list.txt
 
 COPY ${PKGS_LIST} /tmp/main-packages-list.txt
+COPY prepare-image.sh /bin/
 
-RUN dnf upgrade -y && \
-    dnf install -y $(cat /tmp/main-packages-list.txt) && \
-    mkdir -p /var/lib/ironic-inspector && \
-    sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
-    dnf remove -y sqlite && \
-    dnf clean all && \
-    rm -rf /var/cache/{yum,dnf}/*
+RUN prepare-image.sh && \
+  rm -f /bin/prepare-image.sh
 
 COPY ./inspector.conf /tmp/inspector.conf
 RUN crudini --merge /etc/ironic-inspector/inspector.conf < /tmp/inspector.conf && \

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -1,0 +1,11 @@
+ #!/usr/bin/bash
+
+set -ex
+
+dnf upgrade -y
+dnf install -y $(cat /tmp/main-packages-list.txt)
+mkdir -p /var/lib/ironic-inspector
+sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"
+dnf remove -y sqlite
+dnf clean all
+rm -rf /var/cache/{yum,dnf}/*


### PR DESCRIPTION
In the effort of cleaning the Dockerfile, we move the image preparation
steps logic to a script.

(cherry picked from commit 2de4834ac136b4d7245e35b6376209581b421380)