### PR TITLE
Remove chmod command in Dockerfile

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -9,9 +9,8 @@ RUN prepare-image.sh && \
   rm -f /bin/prepare-image.sh
 
 COPY ironic-inspector.conf.j2 /etc/ironic-inspector/
-COPY scripts/ /bin/
+COPY scripts/* /bin/
 
 HEALTHCHECK CMD /bin/runhealthcheck
-RUN chmod +x /bin/runironic-inspector
 
 ENTRYPOINT ["/bin/runironic-inspector"]


### PR DESCRIPTION
The script is already executable, when it's copied to the container
should maintain the original execute bit.

Also changing COPY scripts to explicitly use * to deal with
imagebuilder limitations.

(cherry picked from commit 461a64d9b05e36c7d0952e8daf077250a8937a1a)