### PR TITLE
Bug 1916145: Explicitly set minimum versions of python libraries

### DIFF
--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,5 +1,6 @@
 crudini
 iproute
-openstack-ironic-inspector
+openstack-ironic-inspector >= 10.4.1-0.20201123161216.70fccec.el8
+python3-ironic-lib >= 4.4.1-0.20201218041209.aa7cfec.el8
 psmisc
 sqlite

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -3,7 +3,7 @@
 set -ex
 
 dnf upgrade -y
-dnf install -y $(cat /tmp/main-packages-list.txt)
+xargs -rd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/main-packages-list.txt
 mkdir -p /var/lib/ironic-inspector
 sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"
 dnf remove -y sqlite


### PR DESCRIPTION
To simplify keeping track of minimum installed and required version
of python libraries and ironic packages, we add the versions in
the packages list.
This will also help when cross-tagging packages to test with the
new versions using the prevalidation repositories.