### PR TITLE
Bug 1917966: Force update of dnsmasq

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,7 @@
 FROM ubi8
 
 RUN dnf update -y && \
-    dnf install -y openstack-ironic-inspector crudini psmisc iproute sqlite && \
+    dnf install -y openstack-ironic-inspector "dnsmasq >= 2.79-11.el8_2.2" crudini psmisc iproute sqlite && \
     mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
     dnf remove -y sqlite && \


### PR DESCRIPTION
We need to upgrade the dnsmasq version to fix the vulnerability
described in https://access.redhat.com/security/vulnerabilities/RHSB-2021-001