### PR TITLE
Introduce separate ARG for extra packages list

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,8 +1,9 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.7
 
-ARG PKGS_LIST=main-packages-list.txt
+ENV PKGS_LIST=main-packages-list.txt
+ARG EXTRA_PKGS_LIST
 
-COPY ${PKGS_LIST} /tmp/main-packages-list.txt
+COPY ${PKGS_LIST} ${EXTRA_PKGS_LIST:-$PKGS_LIST} /tmp/
 COPY prepare-image.sh /bin/
 
 RUN prepare-image.sh && \

--- a/prepare-image.sh
+++ b/prepare-image.sh
@@ -1,9 +1,14 @@
  #!/usr/bin/bash
 
-set -ex
+set -euxo pipefail
 
 dnf upgrade -y
-xargs -rd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/main-packages-list.txt
+xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${PKGS_LIST}
+if [[ ! -z ${EXTRA_PKGS_LIST:-} ]]; then
+    if [[ -s /tmp/${EXTRA_PKGS_LIST} ]]; then
+        xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/${EXTRA_PKGS_LIST}
+    fi
+fi
 mkdir -p /var/lib/ironic-inspector
 sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal"
 dnf remove -y sqlite


### PR DESCRIPTION
Convert the current PKGS_LIST to ENV as we should not really touch it.
Introduce the EXTRA_PKGS_LIST ARG to allow specifying a file
containing a list of extra packages to install.
The goal is to allow installing packages from different sources
to test them.

metal3 ref metal3-io#72