### PR TITLE
Bug 1918178: Explicitly set minimum versions of python libraries

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -5,7 +5,7 @@ ARG PKGS_LIST=main-packages-list.txt
 COPY ${PKGS_LIST} /tmp/main-packages-list.txt
 
 RUN dnf upgrade -y && \
-    dnf install -y $(cat /tmp/main-packages-list.txt) && \
+    xargs -rtd'\n' dnf --setopt=install_weak_deps=False install -y < /tmp/main-packages-list.txt && \
     mkdir -p /var/lib/ironic-inspector && \
     sqlite3 /var/lib/ironic-inspector/ironic-inspector.db "pragma journal_mode=wal" && \
     dnf remove -y sqlite && \

--- a/main-packages-list.txt
+++ b/main-packages-list.txt
@@ -1,5 +1,5 @@
 crudini
 iproute
-openstack-ironic-inspector
+openstack-ironic-inspector >= 10.4.1-0.20201103162859.ce6cee6.el8
 psmisc
 sqlite


### PR DESCRIPTION
To simplify keeping track of minimum installed and required version
of python libraries and ironic packages, we add the versions in
the packages list.
This will also help when cross-tagging packages to test with the
new versions using the prevalidation repositories.

partial cherry-pick from https://github.com/openshift/ironic-inspector-image/pull/56